### PR TITLE
Add optional ability to convert markdown bodies into org-mode markup

### DIFF
--- a/README.org
+++ b/README.org
@@ -34,9 +34,14 @@ than having to type "yes".
 ~*reddigg-main*~: show your subreddit list, enter on them will fetch the
 subreddit posts and show them on ~*reddigg*~. On ~*reddigg*~ when you enter on a
 post will fetch the comments and show them on ~*reddigg-comments*~ buffer.
-  
+
 * Variables
 ~reddigg-subs~: list of subreddits you want to show on ~*reddigg-main*~
+
+~reddigg-convert-md-to-org~: control whether to show post/comment
+bodies in org-mode markup. (By default they are inserted into the
+buffer as they are returned by the Reddit API.)
+
 * Commands
 ~reddigg-view-main~: show your subreddit list in ~*reddigg-main*~, ~r/all~ and
 ~r/popular~ are included.
@@ -52,6 +57,3 @@ show it.
 * Remarks
 This mode only lets you view reddit. For a complete interaction with reddit check
 out https://github.com/ahungry/md4rd.
-
-
-  


### PR DESCRIPTION
This requires pandoc, so I made this disabled by default.

Reddit markdown does not directly map into Pandoc markdown so it may cause some inconsistencies while converting but in the cases I tried it worked quite well. Anyway I believe it's better to have a little bit broken org-mode markup instead of markdown inside org-mode buffer.

I understand if you don't want to include something like this, just wanted to share. Let me know if it requires any changes to be accepted.