### PR TITLE
feat(reddigg): Enable read-only mode in reddigg buffers

### DIFF
--- a/reddigg.el
+++ b/reddigg.el
@@ -117,7 +117,8 @@
       (org-set-startup-visibility)
     (org-mode)
     (font-lock-flush))
-  (visual-line-mode))
+  (visual-line-mode)
+  (read-only-mode 1))
 
 (defvar reddigg-replacement-list
   '(("^\\* " . "- ")


### PR DESCRIPTION
There should be no need to edit the content.

Signed-off-by: Arthur Heymans <arthur@aheymans.xyz>